### PR TITLE
Allow user to delete MFA when creating

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -102,6 +102,7 @@ data "aws_iam_policy_document" "users" {
     effect = "Deny"
     not_actions = [
       "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice",
       "iam:EnableMFADevice",
       "iam:GetUser",
       "iam:ListMFADevices",


### PR DESCRIPTION
New MFA processes attempt to delete an MFA device of the same name when creating.